### PR TITLE
Fuel dialog

### DIFF
--- a/Models/c150.xml
+++ b/Models/c150.xml
@@ -2563,5 +2563,47 @@
             </greater-than>
         </condition>
     </animation>
+    
+    <!-- Fuel cap -->
+    <animation>
+        <type>pick</type>
+        <object-name>LFuelCap</object-name>
+        <visible>true</visible>
+        <action>
+            <button>0</button>
+            <repeatable>false</repeatable>
+            <binding>
+                <command>dialog-show</command>
+                <dialog-name>c150-left-fuel-dialog</dialog-name>
+            </binding>
+        </action>
+        <hovered>
+            <binding>
+                <command>set-tooltip</command>
+                <tooltip-id>fuel-cap-port</tooltip-id>
+                <label>Fuel Cap</label>
+            </binding>
+        </hovered>
+    </animation>
+    <animation>
+        <type>pick</type>
+        <object-name>RFuelCap</object-name>
+        <visible>true</visible>
+        <action>
+            <button>0</button>
+            <repeatable>false</repeatable>
+            <binding>
+                <command>dialog-show</command>
+                <dialog-name>c150-right-fuel-dialog</dialog-name>
+            </binding>
+        </action>
+        <hovered>
+            <binding>
+                <command>set-tooltip</command>
+                <tooltip-id>fuel-cap-starboard</tooltip-id>
+                <label>Fuel Cap</label>
+            </binding>
+        </hovered>
+    </animation>
 
 </PropertyList>

--- a/gui/dialogs/c150-left-fuel.xml
+++ b/gui/dialogs/c150-left-fuel.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0"?>
+
+<PropertyList>
+
+    <name>c150-left-fuel-dialog</name>
+    <layout>vbox</layout>
+    <resizable>false</resizable>
+    <modal>false</modal>
+    <draggable>true</draggable>
+
+    <group>
+        <layout>hbox</layout>
+
+        <empty><stretch>true</stretch></empty>
+        <text>
+            <label>Left Fuel Tank</label>
+        </text>
+        <empty><stretch>true</stretch></empty>
+
+        <button>
+            <legend/>
+            <key>Esc</key>
+            <pref-width>16</pref-width>
+            <pref-height>16</pref-height>
+            <binding>
+                <command>dialog-close</command>
+            </binding>
+        </button>
+    </group>
+
+    <hrule/>
+    
+    <group>
+        <layout>vbox</layout>
+        <padding>6</padding>
+        <group>
+            <layout>hbox</layout>
+            <text>
+                <label>Left Fuel Tank:</label>
+                <halign>left</halign>
+            </text>
+            <slider>
+                <name>c150-left-fuel-slider</name>
+                <min>0</min>
+                <max>11.3</max>
+                <live>true</live>
+                <enable>
+                    <less-than>
+                        <property>velocities/groundspeed-kt</property>
+                        <value>1.0</value>
+                    </less-than>
+                </enable>
+                <property>/consumables/fuel/tank[0]/level-gal_us</property>
+                <binding>
+                    <command>dialog-apply</command>
+                    <name>c150-left-fuel-slider</name>
+                </binding>
+            </slider>
+            <group>
+                <layout>vbox</layout>
+                <padding>6</padding>
+                <group>
+                    <layout>hbox</layout>
+                    <padding>6</padding>
+                    <text>
+                        <label>1234</label>
+                        <halign>left</halign>
+                        <format>%.2f</format>
+                        <live>true</live>
+                        <property>/consumables/fuel/tank[0]/level-gal_us</property>
+                    </text>
+                    <text>
+                        <label>gallons</label>
+                        <halign>left</halign>
+                    </text>
+                </group>
+                <group>
+                    <layout>hbox</layout>
+                    <padding>6</padding>
+                    <text>
+                        <label>1234</label>
+                        <halign>left</halign>
+                        <format>%.1f</format>
+                        <live>true</live>
+                        <property>/consumables/fuel/tank[0]/level-lbs</property>
+                    </text>
+                    <text>
+                        <label>pounds</label>
+                        <halign>left</halign>
+                    </text>
+                </group>
+            </group>
+        </group>
+    </group>
+    
+    <group>
+        <layout>hbox</layout>
+        <text>
+            <visible>
+                <greater-than-equals>
+                    <property>velocities/groundspeed-kt</property>
+                    <value>1.0</value>
+                </greater-than-equals>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.1</green>
+                <blue>0.1</blue>
+            </color>
+            <label>Dialog disabled when in movement</label>
+        </text>
+    </group>
+        
+    <hrule/>
+
+    <group>
+        <layout>hbox</layout>
+        <default-padding>6</default-padding>
+        <empty><stretch>true</stretch></empty>
+        <button>
+            <legend>Close</legend>
+            <equal>true</equal>
+            <key>Esc</key>
+            <default>true</default>
+            <binding>
+                <command>dialog-close</command>
+            </binding>
+        </button>
+    </group>
+
+</PropertyList>

--- a/gui/dialogs/c150-right-fuel.xml
+++ b/gui/dialogs/c150-right-fuel.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0"?>
+
+<PropertyList>
+
+    <name>c150-right-fuel-dialog</name>
+    <layout>vbox</layout>
+    <resizable>false</resizable>
+    <modal>false</modal>
+    <draggable>true</draggable>
+
+    <group>
+        <layout>hbox</layout>
+
+        <empty><stretch>true</stretch></empty>
+        <text>
+            <label>Right Fuel Tank</label>
+        </text>
+        <empty><stretch>true</stretch></empty>
+
+        <button>
+            <legend/>
+            <key>Esc</key>
+            <pref-width>16</pref-width>
+            <pref-height>16</pref-height>
+            <binding>
+                <command>dialog-close</command>
+            </binding>
+        </button>
+    </group>
+
+    <hrule/>
+    
+    <group>
+        <layout>vbox</layout>
+        <padding>6</padding>
+        <group>
+            <layout>hbox</layout>
+            <text>
+                <label>Right Fuel Tank:</label>
+                <halign>left</halign>
+            </text>
+            <slider>
+                <name>c150-right-fuel-slider</name>
+                <min>0</min>
+                <max>11.3</max>
+                <live>true</live>
+                <enable>
+                    <less-than>
+                        <property>velocities/groundspeed-kt</property>
+                        <value>1.0</value>
+                    </less-than>
+                </enable>
+                <property>/consumables/fuel/tank[1]/level-gal_us</property>
+                <binding>
+                    <command>dialog-apply</command>
+                    <name>c150-right-fuel-slider</name>
+                </binding>
+            </slider>
+            <group>
+                <layout>vbox</layout>
+                <padding>6</padding>
+                <group>
+                    <layout>hbox</layout>
+                    <padding>6</padding>
+                    <text>
+                        <label>1234</label>
+                        <halign>left</halign>
+                        <format>%.2f</format>
+                        <live>true</live>
+                        <property>/consumables/fuel/tank[1]/level-gal_us</property>
+                    </text>
+                    <text>
+                        <label>gallons</label>
+                        <halign>left</halign>
+                    </text>
+                </group>
+                <group>
+                    <layout>hbox</layout>
+                    <padding>6</padding>
+                    <text>
+                        <label>1234</label>
+                        <halign>left</halign>
+                        <format>%.1f</format>
+                        <live>true</live>
+                        <property>/consumables/fuel/tank[1]/level-lbs</property>
+                    </text>
+                    <text>
+                        <label>pounds</label>
+                        <halign>left</halign>
+                    </text>
+                </group>
+            </group>
+        </group>
+    </group>
+        
+    <group>
+        <layout>hbox</layout>
+        <text>
+            <visible>
+                <greater-than-equals>
+                    <property>velocities/groundspeed-kt</property>
+                    <value>1.0</value>
+                </greater-than-equals>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.1</green>
+                <blue>0.1</blue>
+            </color>
+            <label>Dialog disabled when in movement</label>
+        </text>
+    </group>
+        
+    <hrule/>
+
+    <group>
+        <layout>hbox</layout>
+        <default-padding>6</default-padding>
+        <empty><stretch>true</stretch></empty>
+        <button>
+            <legend>Close</legend>
+            <equal>true</equal>
+            <key>Esc</key>
+            <default>true</default>
+            <binding>
+                <command>dialog-close</command>
+            </binding>
+        </button>
+    </group>
+
+</PropertyList>


### PR DESCRIPTION
Closes #28 

Adds new fuel dialogs when clicking on each fuel cap above the wings
