### PR TITLE
possible solution for bug-51

### DIFF
--- a/Models/c150.xml
+++ b/Models/c150.xml
@@ -993,11 +993,8 @@
             <button>0</button>
             <repeatable>false</repeatable>
             <binding>
-                <command>nasal</command>
-                <script>var fuelOn = getprop("consumables/fuel/tank[0]/selected") or getprop("consumables/fuel/tank[1]/selected");
-                setprop("consumables/fuel/tank[0]/selected", ! fuelOn);
-                setprop("consumables/fuel/tank[1]/selected", ! fuelOn);
-                </script>
+                <command>property-toggle</command>
+                <property>consumables/fuel/both-tanks-selected</property>
             </binding>
         </action>
         <hovered>
@@ -1006,10 +1003,10 @@
                 <tooltip-id>fuelVale</tooltip-id>
                 <label>Fuel Valve Handle: %s</label>
                 <mapping>nasal</mapping>
-                <property>consumables/fuel/tank[0]/selected</property>
+                <property>consumables/fuel/both-tanks-selected</property>
                 <script>
                     var modes = ['OFF', 'ON'];
-                    var fuelOn = getprop("consumables/fuel/tank[0]/selected") or getprop("consumables/fuel/tank[1]/selected");
+                    var fuelOn = getprop("consumables/fuel/both-tanks-selected");
                     return modes[fuelOn];
                 </script>
             </binding>

--- a/Systems/fuel-logic.xml
+++ b/Systems/fuel-logic.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright (c) 2015 onox
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<PropertyList>
+
+    <!-- ============================================================== -->
+    <!-- Fuel selector logic                                            -->
+    <!-- ============================================================== -->
+
+    <logic>
+        <name>Left Fuel Tank</name>
+        <input>
+            <property>/consumables/fuel/both-tanks-selected</property>
+        </input>
+        <output>
+            <property>/consumables/fuel/tank[0]/selected</property>
+        </output>
+    </logic>
+
+    <logic>
+        <name>Right Fuel Tank</name>
+        <input>
+            <property>/consumables/fuel/both-tanks-selected</property>
+        </input>
+        <output>
+            <property>/consumables/fuel/tank[1]/selected</property>
+        </output>
+    </logic>
+
+</PropertyList>

--- a/c150-set.xml
+++ b/c150-set.xml
@@ -172,6 +172,7 @@ The Cessna 150 is the fifth most produced civilian plane ever, with 23,839 aircr
             <path>consumables/fuel/tank[0]/selected</path>
             <path>consumables/fuel/tank[1]/selected</path>
             <path>consumables/fuel/tank[2]/selected</path>
+            <path>consumables/fuel/both-tanks-selected</path>
 
             <path>controls/lighting/instruments-norm</path>
 
@@ -302,6 +303,9 @@ The Cessna 150 is the fifth most produced civilian plane ever, with 23,839 aircr
                 <path>Aircraft/c150/Systems/als-lights.xml</path>
             </property-rule>
 
+            <property-rule n="103">
+                <path>Aircraft/c150/Systems/fuel-logic.xml</path>
+            </property-rule>
 
         </systems>
 
@@ -609,6 +613,7 @@ The Cessna 150 is the fifth most produced civilian plane ever, with 23,839 aircr
                 <level-gal_us type="double">0.0</level-gal_us>
                 <selected type="bool">false</selected>
             </tank>
+            <both-tanks-selected type="bool">true</both-tanks-selected>
         </fuel>
     </consumables>
 


### PR DESCRIPTION
Closes #51 

@Harald67 this is a possible solution to the bug 51:
- it solves the problem of the hovering message with the fuel valve
- it creates a single property that makes either BOTH or NEITHER tank selected (just like the real plane)
- it does not allow the user to select a single tank via the fuel dialog, since this is unrealistic (there is no such switch)
